### PR TITLE
put the promt into its own bash_promt-file, fixes issue #1

### DIFF
--- a/bash_promt
+++ b/bash_promt
@@ -1,0 +1,45 @@
+# ==================== PROMT =================================
+echo "reading ~/.bash_promt"
+# Define some prompt colours -------------------------------------------------
+# see http://tldp.org/HOWTO/Bash-Prompt-HOWTO/x329.html as reference
+DARK_GREY='\[\033[1;30m\]'
+LIGHT_GREY='\[\033[0;37m\]'
+GREEN='\[\033[0;32m\]'
+RED='\[\033[0;31m\]'
+LIGHT_GREEN='\[\033[01;32m\]'
+LIGHT_RED='\[\033[01;31m\]'
+NO_COLOURS='\[\033[0m\]'
+
+# command to caluclate all the needed chars
+function prompt_command {
+  TERMWIDTH=${COLUMNS}  # Find the width of the prompt
+
+  # calculate how much space (in terms of term-width) the calculated/constant parts need
+  TERMWIDTH_FIXED_USED_WIDTH=`echo "┌--[ ${whoami}@${hostname}:ttysXXXX ] ---- ---- [ xx:xx:xx ] --┐\n└->" | wc -c | xargs`
+  let fillsize=${TERMWIDTH}-${TERMWIDTH_FIXED_USED_WIDTH}
+
+  if [ "$fillsize" -gt "0" ]; then
+    fill="--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------"
+    #   It's theoretically possible someone could need more dashes than above, but very unlikely!
+    #   The above should be ONE LINE, it may not cut and paste properly
+    fill="${fill:0:${fillsize}}"
+    newPWD="${PWD}"
+  fi
+
+  if [ "$fillsize" -lt "0" ]; then
+    fill=""
+    let cut=3-${fillsize}
+    newPWD="...${PWD:${cut}}"
+  fi
+}
+
+# And now change PS1 & PS2 to it ---------------------------------------------
+if [ ! -n "$SSH_TTY" ]; then                # local login
+    PS1="${DARK_GREY}┌--[${LIGHT_GREY} \u@\H:\l ${DARK_GREY}] \${fill} [${LIGHT_GREY} \T ${DARK_GREY}] --┐\n└->[${LIGHT_RED} \w ${DARK_GREY}] \\$ ${NO_COLOURS}"
+    export PS1
+else                                        #ssh login
+    export PS1="\u@\h:\W "
+fi
+
+# necessary, otherwise promt will not be shown!
+PROMPT_COMMAND='prompt_command; history -a' # appends cmds to history every time a promt is shown

--- a/bashrc
+++ b/bashrc
@@ -18,46 +18,6 @@ if [ -f /etc/bash_completion ]; then
     fi
 fi
 
-# ==================== PROMT =================================
-function prompt_command {
-  TERMWIDTH=${COLUMNS}  # Find the width of the prompt
-
-  # calculate how much space (in terms of term-width) the calculated/constant parts need
-  TERMWIDTH_FIXED_USED_WIDTH=`echo "┌--[ ${whoami}@${hostname}:ttysXXXX ] ---- ---- [ xx:xx:xx ] --┐\n└->" | wc -c | xargs`
-  let fillsize=${TERMWIDTH}-${TERMWIDTH_FIXED_USED_WIDTH}
-
-  if [ "$fillsize" -gt "0" ]; then
-    fill="--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------"
-    #   It's theoretically possible someone could need more dashes than above, but very unlikely!
-    #   The above should be ONE LINE, it may not cut and paste properly
-    fill="${fill:0:${fillsize}}"
-    newPWD="${PWD}"
-  fi
-
-  if [ "$fillsize" -lt "0" ]; then
-    fill=""
-    let cut=3-${fillsize}
-    newPWD="...${PWD:${cut}}"
-  fi
-}
-# Define some prompt colours -------------------------------------------------
-# see http://tldp.org/HOWTO/Bash-Prompt-HOWTO/x329.html as reference
-DARK_GREY='\[\033[1;30m\]'
-LIGHT_GREY='\[\033[0;37m\]'
-GREEN='\[\033[0;32m\]'
-RED='\[\033[0;31m\]'
-LIGHT_GREEN='\[\033[01;32m\]'
-LIGHT_RED='\[\033[01;31m\]'
-NO_COLOURS='\[\033[0m\]'
-
-# And now change PS1 & PS2 to it ---------------------------------------------
-if [ ! -n "$SSH_TTY" ]; then                # local login
-    PS1="${DARK_GREY}┌--[${LIGHT_GREY} \u@\H:\l ${DARK_GREY}] \${fill} [${LIGHT_GREY} \T ${DARK_GREY}] --┐\n└->[${LIGHT_RED} \w ${DARK_GREY}] \\$ ${NO_COLOURS}"
-    export PS1
-else                                        #ssh login
-    export PS1="\u@\h:\W "
-fi
-
 # ============ History ===============
 export HISTCONTROL=ignoredups # avoid succesive dupes in bash history
 export HISTFILESIZE=1000000000
@@ -66,7 +26,7 @@ export HISTIGNORE="&:ls:bg:fg:cd"
 
 shopt -s histappend # append cmds to bash history instead of overwrite
 
-PROMPT_COMMAND='prompt_command; history -a' # appends cmds to history every time a promt is shown
+#PROMPT_COMMAND='prompt_command; history -a' # appends cmds to history every time a promt is shown
 
 # -----
 
@@ -78,6 +38,10 @@ fi
 # Add bash functions.
 if [ -f ~/.bash_functions ]; then
     source ~/.bash_functions
+fi
+
+if [ -f ~/.bash_promt ]; then
+    source ~/.bash_promt
 fi
 
 [[ -s `brew --prefix`/etc/autojump.sh ]] && . `brew --prefix`/etc/autojump.sh


### PR DESCRIPTION
Remove Promt-related stuff from `bashrc` and put it into its own `bash_promt`-file. The `bashrc` now only checks for the availability of the `bash_promt` and loads it, if available.
